### PR TITLE
Create small thumbnails when taking the photo so to save memory

### DIFF
--- a/app/src/androidTest/java/com/example/ubclaunchpad/launchnote/LaunchNoteTableTest.java
+++ b/app/src/androidTest/java/com/example/ubclaunchpad/launchnote/LaunchNoteTableTest.java
@@ -51,15 +51,15 @@ public class LaunchNoteTableTest {
     @Test
     public void testPicNoteDaoQueries() throws Exception {
         // create first picNote with dummy values
-        PicNote picNote1 = new PicNote("../test/uri1.png", "test picNote1", Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888));
+        PicNote picNote1 = new PicNote("../test/uri1.png", "../test/uri1.png", "test picNote1", Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888));
         picNoteDao.insert(picNote1);
 
         // create second picNote with dummy values
-        PicNote picNote2 = new PicNote("../test/uri2.png", "test picNote2", Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888));
+        PicNote picNote2 = new PicNote("../test/uri2.png", "../test/uri1.png", "test picNote2", Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888));
         picNoteDao.insert(picNote2);
 
         // create second picNote with dummy values
-        PicNote picNote3 = new PicNote("../test/uri3.png", "test picNote3", Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888));
+        PicNote picNote3 = new PicNote("../test/uri3.png","../test/uri1.png", "test picNote3", Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888));
         picNoteDao.insert(picNote3);
 
         // test that we can find the first PicNote

--- a/app/src/main/java/com/example/ubclaunchpad/launchnote/BaseActivity.kt
+++ b/app/src/main/java/com/example/ubclaunchpad/launchnote/BaseActivity.kt
@@ -57,9 +57,10 @@ abstract class BaseActivity : AppCompatActivity() {
                 //registering popup with OnMenuItemClickListener
                 setOnMenuItemClickListener { item ->
                     if (item.itemId == R.id.take_photo_item) {
+                        val b = Bundle()
                         val takePhotoActivityIntent = Intent(applicationContext, TakePhotoActivity::class.java)
                                 .apply { flags = FLAG_ACTIVITY_REORDER_TO_FRONT }
-                        startActivity(takePhotoActivityIntent)
+                        startActivity(takePhotoActivityIntent, b)
                     } else if (item.itemId == R.id.add_from_library_item) {
                         val galleryActivityIntent = Intent(applicationContext, GalleryActivity::class.java)
                                 .apply { flags = FLAG_ACTIVITY_REORDER_TO_FRONT }

--- a/app/src/main/java/com/example/ubclaunchpad/launchnote/addPhoto/GalleryActivity.kt
+++ b/app/src/main/java/com/example/ubclaunchpad/launchnote/addPhoto/GalleryActivity.kt
@@ -9,17 +9,15 @@ import android.provider.MediaStore
 import android.view.View
 import android.widget.ImageView
 import android.widget.Toast
-
+import butterknife.ButterKnife
+import butterknife.OnClick
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.target.SimpleTarget
 import com.bumptech.glide.request.transition.Transition
+import com.example.ubclaunchpad.launchnote.BaseActivity
 import com.example.ubclaunchpad.launchnote.R
 import com.example.ubclaunchpad.launchnote.database.LaunchNoteDatabase
 import com.example.ubclaunchpad.launchnote.models.PicNote
-
-import butterknife.ButterKnife
-import butterknife.OnClick
-import com.example.ubclaunchpad.launchnote.BaseActivity
 import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers
@@ -85,7 +83,8 @@ class GalleryActivity : BaseActivity() {
         if (photoUri != null && photoBitmap != null) {
             // TODO: parse out the description
             // passing in empty string for now
-            picNoteToSave = PicNote(photoUri.toString(), "", photoBitmap)
+            // todo vpineda optimize this save
+            picNoteToSave = PicNote(photoUri.toString(), photoUri.toString(),"", photoBitmap)
 
             // insert image into database on a different thread
             LaunchNoteDatabase.getDatabase(this)?.let {

--- a/app/src/main/java/com/example/ubclaunchpad/launchnote/addPhoto/GalleryActivity.kt
+++ b/app/src/main/java/com/example/ubclaunchpad/launchnote/addPhoto/GalleryActivity.kt
@@ -35,6 +35,10 @@ class GalleryActivity : BaseActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         photoView = findViewById(R.id.imgView)
+        if(savedInstanceState?.containsKey(GALLERYBROWSEOPEN) != true) {
+            loadImageFromGallery()
+        }
+        savedInstanceState?.putBoolean(GALLERYBROWSEOPEN, true)
         ButterKnife.bind(this)
     }
 
@@ -66,15 +70,18 @@ class GalleryActivity : BaseActivity() {
                         }
                     })
         } else {
-            Toast.makeText(this, "You haven't picked an image", Toast.LENGTH_LONG).show()
-
+            Toast.makeText(this, "You didn't select an image!", Toast.LENGTH_LONG).show()
+            finish()
         }
     }
 
     @OnClick(R.id.buttonLoadPicture)
     fun loadImageFromGallery(view: View) {
-        val galleryIntent = Intent(Intent.ACTION_PICK, MediaStore.Images.Media.EXTERNAL_CONTENT_URI)
+        loadImageFromGallery()
+    }
 
+    private fun loadImageFromGallery() {
+        val galleryIntent = Intent(Intent.ACTION_PICK, MediaStore.Images.Media.EXTERNAL_CONTENT_URI)
         startActivityForResult(galleryIntent, RESULT_LOAD_IMG)
     }
 
@@ -93,7 +100,6 @@ class GalleryActivity : BaseActivity() {
                         .observeOn(AndroidSchedulers.mainThread())
                         .subscribe()
             }
-
             finish()
         } else {
             Toast.makeText(this, "You haven't picked an image", Toast.LENGTH_LONG).show()
@@ -101,7 +107,7 @@ class GalleryActivity : BaseActivity() {
     }
 
     companion object {
-
+        internal const val GALLERYBROWSEOPEN = "GALLERYBROWSEOPEN"
         private val RESULT_LOAD_IMG = 1
     }
 }

--- a/app/src/main/java/com/example/ubclaunchpad/launchnote/addPhoto/TakePhotoActivity.kt
+++ b/app/src/main/java/com/example/ubclaunchpad/launchnote/addPhoto/TakePhotoActivity.kt
@@ -2,25 +2,31 @@ package com.example.ubclaunchpad.launchnote.addPhoto
 
 import android.app.Activity
 import android.content.Intent
+import android.graphics.Bitmap
 import android.net.Uri
-import android.os.Bundle
 import android.os.Environment
 import android.provider.MediaStore
 import android.support.v4.content.FileProvider
+import android.util.Log
 import android.view.View
+import android.widget.Toast
+import com.bumptech.glide.Glide
+import com.bumptech.glide.load.resource.bitmap.CenterInside
+import com.bumptech.glide.request.RequestOptions
 import com.example.ubclaunchpad.launchnote.BaseActivity
 import com.example.ubclaunchpad.launchnote.R
-
 import com.example.ubclaunchpad.launchnote.database.LaunchNoteDatabase
 import com.example.ubclaunchpad.launchnote.models.PicNote
+import com.example.ubclaunchpad.launchnote.photoBrowser.AllPhotosFragment
 import io.reactivex.Observable
+import io.reactivex.ObservableEmitter
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers
-
 import java.io.File
+import java.io.FileOutputStream
 import java.io.IOException
 import java.text.SimpleDateFormat
-import java.util.Date
+import java.util.*
 
 class TakePhotoActivity : BaseActivity() {
 
@@ -48,6 +54,7 @@ class TakePhotoActivity : BaseActivity() {
             try {
                 imageFile = createImageFile()
             } catch (e: IOException) {
+                Toast.makeText(view.context, "Cannot save file", Toast.LENGTH_LONG).show()
                 e.printStackTrace()
             }
 
@@ -62,13 +69,52 @@ class TakePhotoActivity : BaseActivity() {
         }
     }
 
+    private fun compressImage(): Uri {
+        // Compress the images in such a way that we are able to expand them correctly later on
+        val maxSize  = maxOf(resources.displayMetrics.widthPixels, resources.displayMetrics.heightPixels) / AllPhotosFragment.NUM_COLUMNS_PORTRAIT
+        val compressedBmp = Glide.with(this)
+                .asBitmap()
+                .load(currentImageUri)
+                .apply(RequestOptions.bitmapTransform(CenterInside()))
+                .apply(RequestOptions().override(maxSize)).submit().get()
+        val f = createImageFile(true)
+        var out: FileOutputStream? = null;
+        try {
+            out = FileOutputStream(f)
+            compressedBmp.compress(Bitmap.CompressFormat.PNG, 100, out)
+        } finally {
+                try {
+                    if (out != null) {
+                        out.close();
+                    }
+                } catch (e: IOException) {
+                    e.printStackTrace()
+                }
+        }
+        return FileProvider.getUriForFile(this, AUTHORITY, f)
+    }
+
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         if (requestCode == TAKE_PHOTO_REQUEST_CODE) {
             if (resultCode == Activity.RESULT_OK) {
                 /* If the picture was taken and saved to internal storage successfully,
                 let's save its URI to the database
                  */
-                saveImgToDB(currentImageUri)
+                Observable.just(requestCode)
+                        .observeOn(Schedulers.io())
+                        .flatMap({
+                            Observable.create<Unit> {
+                                Log.i("INFO", "Got to call 1")
+                                val compressedImageUri = compressImage()
+                                saveImgToDB(currentImageUri, compressedImageUri, it)
+                            }
+                        })
+                        .observeOn(AndroidSchedulers.mainThread())
+                        .subscribe {
+                            Log.i("INFO", "Got to call 2")
+                            Glide.get(this).clearMemory()
+                            finish()
+                        }
             } else if (resultCode == Activity.RESULT_CANCELED) {
                 /* I the picture was not taken or not saved to internal storage, delete
                  the file that had been created (where the picture was supposed to go)
@@ -81,33 +127,37 @@ class TakePhotoActivity : BaseActivity() {
         }
     }
 
-    private fun saveImgToDB(imageURI: Uri) {
+    private fun saveImgToDB(imageURI: Uri, compressedUri: Uri, onDone: ObservableEmitter<Unit>) {
         // TODO: parse out the description
         // passing in empty string for now
-        picNoteToSave = PicNote(imageURI.toString(), "", null)
+        picNoteToSave = PicNote(imageURI.toString(), compressedUri.toString(),"", null)
 
         // insert image into database on a different thread
         LaunchNoteDatabase.getDatabase(this)?.let {
             Observable.fromCallable { it.picNoteDao().insert(picNoteToSave) }
                         .subscribeOn(Schedulers.io())
                     .observeOn(AndroidSchedulers.mainThread())
-                    .subscribe()
+                    .subscribe {
+                        onDone.onNext(Unit)
+                        onDone.onComplete()
+                    }
         }
-        finish()
-
     }
 
     @Throws(IOException::class)
-    private fun createImageFile(): File {
+    private fun createImageFile(forCompressed: Boolean = false): File {
         // First, create file name
         val timestamp = SimpleDateFormat(DATE_FORMAT).format(Date())
-        val fileName = JPEG + timestamp
+        val compressExt = if(forCompressed) "_cmp" else ""
+        val fileName = JPEG + timestamp + compressExt
         // Directory where the file will be stored (check file_paths.xml)
         val dir = getExternalFilesDir(Environment.DIRECTORY_PICTURES)
         // Create file
         val image = File.createTempFile(fileName, IMAGE_EXTENSION, dir)
-        currentImagePath = image.absolutePath
-        currentImageFile = image
+        if(!forCompressed) {
+            currentImagePath = image.absolutePath
+            currentImageFile = image
+        }
         return image
     }
 

--- a/app/src/main/java/com/example/ubclaunchpad/launchnote/models/PicNote.kt
+++ b/app/src/main/java/com/example/ubclaunchpad/launchnote/models/PicNote.kt
@@ -3,7 +3,11 @@ package com.example.ubclaunchpad.launchnote.models
 import android.arch.persistence.room.Entity
 import android.arch.persistence.room.Ignore
 import android.arch.persistence.room.PrimaryKey
+import android.content.Context
 import android.graphics.Bitmap
+import com.example.ubclaunchpad.launchnote.database.LaunchNoteDatabase
+import java.io.File
+import java.io.IOException
 
 /**
  * Model class for representing one photo
@@ -11,6 +15,7 @@ import android.graphics.Bitmap
 @Entity
 data class PicNote(
         var imageUri: String = "",
+        var compressedImageUri: String = "",
         var description: String = "",
         @Ignore
         var image: Bitmap? = null
@@ -20,4 +25,24 @@ data class PicNote(
 
     var classId: Int = 0
     var projectId: Int = 0
+
+    companion object {
+        fun deleteFromDb(context: Context, pn: PicNote): Boolean {
+            var success = true
+            try {
+                File(pn.compressedImageUri).delete()
+            } catch (e: IOException) {
+                e.printStackTrace()
+                success = false
+            }
+            try {
+                File(pn.imageUri).delete()
+            } catch (e: IOException) {
+                e.printStackTrace()
+                success = false
+            }
+            LaunchNoteDatabase.getDatabase(context)?.picNoteDao()?.delete(pn)
+            return success
+        }
+    }
 }

--- a/app/src/main/java/com/example/ubclaunchpad/launchnote/models/PicNote.kt
+++ b/app/src/main/java/com/example/ubclaunchpad/launchnote/models/PicNote.kt
@@ -27,6 +27,10 @@ data class PicNote(
     var projectId: Int = 0
 
     companion object {
+        /**
+         * Deletes a PicNote from the database and it also deletes any photo that the database is
+         * referencing
+         */
         fun deleteFromDb(context: Context, pn: PicNote): Boolean {
             var success = true
             try {

--- a/app/src/main/java/com/example/ubclaunchpad/launchnote/photoBrowser/AllPhotosAdapter.kt
+++ b/app/src/main/java/com/example/ubclaunchpad/launchnote/photoBrowser/AllPhotosAdapter.kt
@@ -2,7 +2,6 @@ package com.example.ubclaunchpad.launchnote.photoBrowser
 
 import android.content.Context
 import android.content.Intent
-import android.graphics.Bitmap
 import android.graphics.PorterDuff
 import android.support.v4.content.ContextCompat
 import android.support.v7.widget.RecyclerView
@@ -13,8 +12,7 @@ import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
 import com.bumptech.glide.Glide
-import com.bumptech.glide.request.target.SimpleTarget
-import com.bumptech.glide.request.transition.Transition
+import com.bumptech.glide.request.RequestOptions
 import com.example.ubclaunchpad.launchnote.R
 import com.example.ubclaunchpad.launchnote.models.PicNote
 
@@ -25,7 +23,11 @@ class AllPhotosAdapter(): RecyclerView.Adapter<AllPhotosAdapter.ViewHolder>() {
     private lateinit var picNotes: List<PicNote>
     private lateinit var context: Context
     private lateinit var picNotesSelected: Set<PicNote>
+    private var scale: Int = 500
+
     var onOnImageActionListener: onImageActionListener? = null;
+
+
 
     /**
      * The secondary constructor
@@ -33,6 +35,7 @@ class AllPhotosAdapter(): RecyclerView.Adapter<AllPhotosAdapter.ViewHolder>() {
      * and also set the picNotes and context fields
      */
     constructor(context: Context, picNotes: List<PicNote>, picNotesSelected: Set<PicNote>) : this() {
+        this.scale = context.resources.displayMetrics.widthPixels / 3
         this.picNotes = picNotes
         this.context = context
         this.picNotesSelected = picNotesSelected
@@ -40,48 +43,45 @@ class AllPhotosAdapter(): RecyclerView.Adapter<AllPhotosAdapter.ViewHolder>() {
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val picNote = picNotes[position]
-        holder.description.text = picNote.description
+        // Size of every scaled image that we are going to put on the view
+        val size = maxOf(context.resources.displayMetrics.widthPixels, context.resources.displayMetrics.heightPixels) / AllPhotosFragment.NUM_COLUMNS_PORTRAIT
 
         // get Bitmap from the picNote's URI and show it in an ImageView
         Glide.with(context)
                 .asBitmap()
-                .load(picNote.imageUri)
-                .into(object : SimpleTarget<Bitmap>() {
-                    override fun onResourceReady(resource: Bitmap?, transition: Transition<in Bitmap>?) {
-                        // set the image
-                        holder.image.setImageBitmap(resource)
-                        // TODO: replace with real description
-                        // set the text
-                        holder.description.text = "fake description"
+                .apply(RequestOptions().override(size))
+                .load(picNote.compressedImageUri)
+                .into(holder.image)
 
-                        holder.image.setOnClickListener {
-                            if(picNotesSelected.isNotEmpty()){
-                                if(picNotesSelected.contains(picNote)){
-                                    onOnImageActionListener?.onImageDeselected(picNote)
-                                } else {
-                                    onOnImageActionListener?.onImageSelected(picNote)
-                                }
-                            } else {
-                                val intent = Intent(context, ExpandPhotoActivity::class.java)
-                                intent.putExtra(ExpandPhotoActivity.EXTRA_INTENT_IMAGE_URI, picNote.imageUri)  // pass in 1 imageuri to ExpandPhotoActivity
-                                context.startActivity(intent)
-                            }
-                        }
+        // set the text
+        holder.description.text = "fake description"
 
-                        holder.image.setOnLongClickListener {
-                            onOnImageActionListener?.onImageSelected(picNote)
-                            true
-                        }
+        holder.image.setOnClickListener {
+            if(picNotesSelected.isNotEmpty()){
+                if(picNotesSelected.contains(picNote)){
+                    onOnImageActionListener?.onImageDeselected(picNote)
+                } else {
+                    onOnImageActionListener?.onImageSelected(picNote)
+                }
+            } else {
+                val intent = Intent(context, ExpandPhotoActivity::class.java)
+                intent.putExtra(ExpandPhotoActivity.EXTRA_INTENT_IMAGE_URI, picNote.imageUri)  // pass in 1 imageuri to ExpandPhotoActivity
+                context.startActivity(intent)
+            }
+        }
 
-                        if(picNotesSelected.contains(picNote)) {
-                            Log.i("INFO", "Marking " + picNote + " as selected!")
-                            val color = ContextCompat.getColor(context, R.color.imageSelectionMask)
-                            holder.image.setColorFilter( color, PorterDuff.Mode.DARKEN )
-                        } else {
-                            holder.image.clearColorFilter()
-                        }
-                    }
-                })
+        holder.image.setOnLongClickListener {
+            onOnImageActionListener?.onImageSelected(picNote)
+            true
+        }
+
+        if(picNotesSelected.contains(picNote)) {
+            Log.i("INFO", "Marking " + picNote + " as selected!")
+            val color = ContextCompat.getColor(context, R.color.imageSelectionMask)
+            holder.image.setColorFilter( color, PorterDuff.Mode.DARKEN )
+        } else {
+            holder.image.clearColorFilter()
+        }
     }
 
     override fun getItemCount(): Int {

--- a/app/src/main/java/com/example/ubclaunchpad/launchnote/photoBrowser/AllPhotosAdapter.kt
+++ b/app/src/main/java/com/example/ubclaunchpad/launchnote/photoBrowser/AllPhotosAdapter.kt
@@ -23,11 +23,10 @@ class AllPhotosAdapter(): RecyclerView.Adapter<AllPhotosAdapter.ViewHolder>() {
     private lateinit var picNotes: List<PicNote>
     private lateinit var context: Context
     private lateinit var picNotesSelected: Set<PicNote>
+    // Size of every scaled image that we are going to put on the view
     private var scale: Int = 500
 
     var onOnImageActionListener: onImageActionListener? = null;
-
-
 
     /**
      * The secondary constructor
@@ -35,7 +34,7 @@ class AllPhotosAdapter(): RecyclerView.Adapter<AllPhotosAdapter.ViewHolder>() {
      * and also set the picNotes and context fields
      */
     constructor(context: Context, picNotes: List<PicNote>, picNotesSelected: Set<PicNote>) : this() {
-        this.scale = context.resources.displayMetrics.widthPixels / 3
+        this.scale = maxOf(context.resources.displayMetrics.widthPixels, context.resources.displayMetrics.heightPixels) / AllPhotosFragment.NUM_COLUMNS_PORTRAIT
         this.picNotes = picNotes
         this.context = context
         this.picNotesSelected = picNotesSelected
@@ -43,13 +42,10 @@ class AllPhotosAdapter(): RecyclerView.Adapter<AllPhotosAdapter.ViewHolder>() {
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val picNote = picNotes[position]
-        // Size of every scaled image that we are going to put on the view
-        val size = maxOf(context.resources.displayMetrics.widthPixels, context.resources.displayMetrics.heightPixels) / AllPhotosFragment.NUM_COLUMNS_PORTRAIT
-
         // get Bitmap from the picNote's URI and show it in an ImageView
         Glide.with(context)
                 .asBitmap()
-                .apply(RequestOptions().override(size))
+                .apply(RequestOptions().override(this.scale))
                 .load(picNote.compressedImageUri)
                 .into(holder.image)
 

--- a/app/src/main/java/com/example/ubclaunchpad/launchnote/photoBrowser/AllPhotosFragment.kt
+++ b/app/src/main/java/com/example/ubclaunchpad/launchnote/photoBrowser/AllPhotosFragment.kt
@@ -9,6 +9,7 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import com.example.ubclaunchpad.launchnote.R
 import com.example.ubclaunchpad.launchnote.database.LaunchNoteDatabase
 import com.example.ubclaunchpad.launchnote.models.PicNote
@@ -52,13 +53,12 @@ class AllPhotosFragment() : Fragment() {
      */
     fun removeSelection() {
         Flowable.fromCallable {
-            LaunchNoteDatabase.getDatabase(activity)?.let {
-                picNotesSelected.forEach {pn ->
-                    Log.i("DEL","Deleting: " + pn)
-                    it.picNoteDao().delete(pn)
-                }
-                picNotesSelected.clear()
+            picNotesSelected.forEach {pn ->
+                Log.i("DEL","Deleting: " + pn)
+                val success = PicNote.deleteFromDb(context, pn)
+                if (!success) Toast.makeText(context, "Cannot delete ${pn.id}", Toast.LENGTH_LONG).show()
             }
+            picNotesSelected.clear()
         }.subscribeOn(Schedulers.io()).subscribe {
             rerenderPhotoGrid()
             onListener?.onEditPhotoMode(false)

--- a/app/src/main/java/com/example/ubclaunchpad/launchnote/photoBrowser/PhotoBrowserActivity.kt
+++ b/app/src/main/java/com/example/ubclaunchpad/launchnote/photoBrowser/PhotoBrowserActivity.kt
@@ -14,7 +14,6 @@ import com.example.ubclaunchpad.launchnote.R
 import com.example.ubclaunchpad.launchnote.models.PicNote
 import com.example.ubclaunchpad.launchnote.toolbar.PhotoNavigatonToolbarFragment
 import io.reactivex.Observable
-import io.reactivex.Observer
 import io.reactivex.android.schedulers.AndroidSchedulers
 import kotlinx.android.synthetic.main.activity_photo_browser.*
 import kotlinx.android.synthetic.main.photo_navigation_bar.*
@@ -104,6 +103,9 @@ class PhotoBrowserActivity : BaseActivity(), AllPhotosFragment.OnEditPhotoMode, 
         Log.i("INFO","Clicked " + butonInfo)
         when(butonInfo) {
             R.id.edit_toolbar_back_btn -> {
+                customPagerAdapter.currentFragment!!.cancelSelection()
+            }
+            R.id.edit_toolbar_text_view -> {
                 customPagerAdapter.currentFragment!!.cancelSelection()
             }
             R.id.edit_toolbar_delete_btn -> {

--- a/app/src/main/java/com/example/ubclaunchpad/launchnote/toolbar/PhotoNavigatonToolbarFragment.kt
+++ b/app/src/main/java/com/example/ubclaunchpad/launchnote/toolbar/PhotoNavigatonToolbarFragment.kt
@@ -116,7 +116,7 @@ class PhotoNavigatonToolbarFragment : Fragment() {
         object NormalMode: ToolbarMode(ArrayList(normalModeButtons.toList()))
 
         companion object {
-            val editButtonsListeners = arrayOf(R.id.edit_toolbar_back_btn, R.id.edit_toolbar_delete_btn)
+            val editButtonsListeners = arrayOf(R.id.edit_toolbar_back_btn, R.id.edit_toolbar_delete_btn, R.id.edit_toolbar_text_view)
             val editButtons = arrayOf(ElementInfo(R.id.edit_toolbar_layout, ArrayList(editButtonsListeners.toList())))
             val normalModeButtons = arrayOf<ElementInfo>(ElementInfo(R.id.photo_view_title))
         }

--- a/app/src/main/res/layout/photo_navigation_bar.xml
+++ b/app/src/main/res/layout/photo_navigation_bar.xml
@@ -50,6 +50,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="?attr/actionBarSize"
                     android:gravity="center"
+                    android:id="@+id/edit_toolbar_text_view"
                     style="@style/toolbarTextStyle"
                     android:text="@string/toolbar_edit"/>
 
@@ -59,12 +60,13 @@
                     android:orientation="horizontal"
                     android:gravity="end">
                     <ImageButton
-                        android:layout_width="30dp"
+                        android:layout_width="wrap_content"
                         android:id="@+id/edit_toolbar_delete_btn"
                         android:layout_height="?attr/actionBarSize"
                         android:background="?attr/selectableItemBackground"
                         android:src="@android:drawable/ic_menu_delete"
-                        android:layout_marginRight="14dp"/>
+                        android:paddingEnd="15dp"
+                        android:paddingStart="15dp"/>
 
                 </LinearLayout>
             </LinearLayout>


### PR DESCRIPTION
Multiple fixes in this commit ( fixes #49 )

- Remove files that were created (previously we only deleted the entry from the db)
- PnR stuff related on how we load images
- Database change: now we store a thumbnail that gets loaded into the recyclerView

RAM usage drops to around 60 MB with 30 images loaded to all of the 3 fragments.
Butter smooth animations on my phone 👍 