### PR TITLE
Sy 65 upload bug

### DIFF
--- a/app/src/main/java/com/example/ubclaunchpad/launchnote/addPhoto/GalleryActivity.kt
+++ b/app/src/main/java/com/example/ubclaunchpad/launchnote/addPhoto/GalleryActivity.kt
@@ -72,14 +72,7 @@ class GalleryActivity : BaseActivity() {
                         }
                     })
                     .observeOn(AndroidSchedulers.mainThread())
-                    .subscribe {
-                        Log.d("TakePhotoActivity", "Clearing Glide cache")
-                        Glide.get(this).clearMemory()
-                        val intent = Intent()
-                        intent.putExtra(BaseActivity.PIC_NOTE_KEY, picNoteToSave)
-                        setResult(Activity.RESULT_OK, intent)
-                        finish()
-                    }
+                    .subscribe()
 
             // load Bitmap using Glide
             Glide.with(this)

--- a/app/src/main/java/com/example/ubclaunchpad/launchnote/addPhoto/GalleryActivity.kt
+++ b/app/src/main/java/com/example/ubclaunchpad/launchnote/addPhoto/GalleryActivity.kt
@@ -17,7 +17,6 @@ import com.bumptech.glide.request.target.SimpleTarget
 import com.bumptech.glide.request.transition.Transition
 import com.example.ubclaunchpad.launchnote.BaseActivity
 import com.example.ubclaunchpad.launchnote.R
-import com.example.ubclaunchpad.launchnote.database.LaunchNoteDatabase
 import com.example.ubclaunchpad.launchnote.models.PicNote
 import com.example.ubclaunchpad.launchnote.utils.PhotoUtils
 import io.reactivex.Observable
@@ -31,8 +30,8 @@ class GalleryActivity : BaseActivity() {
 
     lateinit var photoView: ImageView
     var photoBitmap: Bitmap? = null
-    var photoUri: Uri? = null
-    var picNoteToSave: PicNote? = null
+    private var picNoteToSave: PicNote? = null
+    private lateinit var photoUri: Uri
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -59,6 +58,29 @@ class GalleryActivity : BaseActivity() {
         if (requestCode == RESULT_LOAD_IMG && resultCode == Activity.RESULT_OK && data != null) {
             // get Image from data
             photoUri = data.data
+
+            // compress image, then save it
+            Observable.just(requestCode)
+                    .observeOn(Schedulers.io())
+                    .flatMap({
+                        Observable.create<Unit> {
+                            picNoteToSave = PicNote(photoUri.toString(), photoUri.toString(),"", "")
+                            val compressedImageUri = PhotoUtils.compressImage(this, photoUri)
+                            picNoteToSave?.compressedImageUri = compressedImageUri.toString()
+                            it.onNext(Unit)
+                            it.onComplete()
+                        }
+                    })
+                    .observeOn(AndroidSchedulers.mainThread())
+                    .subscribe {
+                        Log.d("TakePhotoActivity", "Clearing Glide cache")
+                        Glide.get(this).clearMemory()
+                        val intent = Intent()
+                        intent.putExtra(BaseActivity.PIC_NOTE_KEY, picNoteToSave)
+                        setResult(Activity.RESULT_OK, intent)
+                        finish()
+                    }
+
             // load Bitmap using Glide
             Glide.with(this)
                     .asBitmap()
@@ -90,24 +112,14 @@ class GalleryActivity : BaseActivity() {
 
     @OnClick(R.id.buttonSavePicture)
     fun saveImageToDb(view: View) {
-        if (photoUri != null && photoBitmap != null) {
+        if (photoBitmap != null) {
             // TODO: parse out the description
             // passing in empty string for now
             // todo vpineda optimize this save
-            photoUri?.let {
-                Observable.just(
-                        {
-                            val compressedImageUri = PhotoUtils.compressImage(this, it)
-                            picNoteToSave?.compressedImageUri = compressedImageUri.toString()
-                        })
-                        .observeOn(Schedulers.io())
-                        .subscribe {
-                            val intent = Intent()
-                            intent.putExtra(BaseActivity.PIC_NOTE_KEY, picNoteToSave)
-                            setResult(Activity.RESULT_OK, intent)
-                            finish()
-                        }
-            }
+            val intent = Intent()
+            intent.putExtra(BaseActivity.PIC_NOTE_KEY, picNoteToSave)
+            setResult(Activity.RESULT_OK, intent)
+            finish()
         } else {
             Toast.makeText(this, "You haven't picked an image", Toast.LENGTH_LONG).show()
         }

--- a/app/src/main/java/com/example/ubclaunchpad/launchnote/addPhoto/TakePhotoActivity.kt
+++ b/app/src/main/java/com/example/ubclaunchpad/launchnote/addPhoto/TakePhotoActivity.kt
@@ -37,7 +37,7 @@ class TakePhotoActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        if(!intent.hasExtra(PHOTOFRAGMENTINIT)) {
+        if (!intent.hasExtra(PHOTOFRAGMENTINIT)) {
             takePhoto()
         }
         intent.putExtra(PHOTOFRAGMENTINIT, true)
@@ -51,7 +51,10 @@ class TakePhotoActivity : AppCompatActivity() {
             // File where the image goes
             var imageFile: File? = null
             try {
-                imageFile = PhotoUtils.createImageFile(this, true)
+                imageFile = PhotoUtils.createImageFile(this)
+                // save the un
+                currentImagePath = imageFile.absolutePath
+                currentImageFile = imageFile
             } catch (e: IOException) {
                 Toast.makeText(this, "Cannot save file", Toast.LENGTH_LONG).show()
                 e.printStackTrace()
@@ -74,7 +77,7 @@ class TakePhotoActivity : AppCompatActivity() {
                 /* If the picture was taken and saved to internal storage successfully,
                 let's compress it and then save both URIs to the database
                  */
-                val pn =  PicNote(currentImageUri.toString())
+                val pn = PicNote(currentImageUri.toString())
                 Observable.just(requestCode)
                         .observeOn(Schedulers.io())
                         .flatMap({

--- a/app/src/main/java/com/example/ubclaunchpad/launchnote/addPhoto/TakePhotoActivity.kt
+++ b/app/src/main/java/com/example/ubclaunchpad/launchnote/addPhoto/TakePhotoActivity.kt
@@ -52,7 +52,7 @@ class TakePhotoActivity : AppCompatActivity() {
             var imageFile: File? = null
             try {
                 imageFile = PhotoUtils.createImageFile(this)
-                // save the un
+                // save the uncompressed image
                 currentImagePath = imageFile.absolutePath
                 currentImageFile = imageFile
             } catch (e: IOException) {

--- a/app/src/main/java/com/example/ubclaunchpad/launchnote/utils/PhotoUtils.kt
+++ b/app/src/main/java/com/example/ubclaunchpad/launchnote/utils/PhotoUtils.kt
@@ -16,7 +16,7 @@ import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
 import java.text.SimpleDateFormat
-import java.util.*
+import java.util.Date
 
 
 object PhotoUtils {

--- a/app/src/main/java/com/example/ubclaunchpad/launchnote/utils/PhotoUtils.kt
+++ b/app/src/main/java/com/example/ubclaunchpad/launchnote/utils/PhotoUtils.kt
@@ -18,17 +18,32 @@ import java.io.IOException
 import java.text.SimpleDateFormat
 import java.util.*
 
-/**
- * Created by sherryuan on 2018-03-10.
- */
-object PhotoUtils {
 
-    fun compressImage(context: Context, currentImageUri: Uri): Uri {
+object PhotoUtils {
+    /**
+     * This function gets called when we want to create a image file
+     * @param forCompressed normally if we create a file we want the currentImageReference to point to it
+     *                      but in the case of creating a compressed image we dont want that, furthermore
+     *                      we append cmp to the image URI
+     */
+    @Throws(IOException::class)
+    fun createImageFile(context: Context, forCompressed: Boolean = false): File {
+        // First, create file name
+        val timestamp = SimpleDateFormat(TakePhotoActivity.DATE_FORMAT).format(Date())
+        val compressExt = if (forCompressed) "_cmp" else ""
+        val fileName = TakePhotoActivity.JPEG + timestamp + compressExt
+        // Directory where the file will be stored (check file_paths.xml)
+        val dir = context.getExternalFilesDir(Environment.DIRECTORY_PICTURES)
+        // Create file
+        return File.createTempFile(fileName, TakePhotoActivity.IMAGE_EXTENSION, dir)
+    }
+
+    fun compressImage(context: Context, photoUri: Uri): Uri {
         // Compress the images in such a way that we are able to expand them correctly later on
-        val maxSize  = maxOf(context.resources.displayMetrics.widthPixels, context.resources.displayMetrics.heightPixels) / AllPhotosFragment.NUM_COLUMNS_PORTRAIT
+        val maxSize = maxOf(context.resources.displayMetrics.widthPixels, context.resources.displayMetrics.heightPixels) / AllPhotosFragment.NUM_COLUMNS_PORTRAIT
         val compressedBmp = Glide.with(context)
                 .asBitmap()
-                .load(currentImageUri)
+                .load(photoUri)
                 .apply(RequestOptions.bitmapTransform(CenterInside()))
                 .apply(RequestOptions().override(maxSize)).submit().get()
         // Creates the temp file that we write to
@@ -46,27 +61,6 @@ object PhotoUtils {
             }
         }
         Log.d("TakePhotoActivity", "Finished compressing file")
-        return if(out == null) currentImageUri else FileProvider.getUriForFile(context, TakePhotoActivity.AUTHORITY, f)
+        return if (out == null) photoUri else FileProvider.getUriForFile(context, TakePhotoActivity.AUTHORITY, f)
     }
-
-    /**
-     * This function gets called when we want to create a image file
-     * @param forCompressed normally if we create a file we want the currentImageReference to point to it
-     *                      but in the case of creating a compressed image we dont want that, furthermore
-     *                      we append cmp to the image URI
-     */
-    @Throws(IOException::class)
-    fun createImageFile(context: Context,forCompressed: Boolean = false): File {
-        // First, create file name
-        val timestamp = SimpleDateFormat(TakePhotoActivity.DATE_FORMAT).format(Date())
-        val compressExt = if(forCompressed) "_cmp" else ""
-        val fileName = TakePhotoActivity.JPEG + timestamp + compressExt
-        // Directory where the file will be stored (check file_paths.xml)
-        val dir = context.getExternalFilesDir(Environment.DIRECTORY_PICTURES)
-        // Create file
-        val image = File.createTempFile(fileName, TakePhotoActivity.IMAGE_EXTENSION, dir)
-
-        return image
-    }
-
 }


### PR DESCRIPTION
Fixed a bug in the master branch where if you upload a photo from gallery, it would appear twice in AllPhotosFragment because we were saving the image twice. 

Moved createImageFile and compressImage to a utils object so that they can be reused.